### PR TITLE
Parallel computation control functions

### DIFF
--- a/cyvlfeat/__init__.py
+++ b/cyvlfeat/__init__.py
@@ -1,5 +1,7 @@
 import cyvlfeat.sift
 import cyvlfeat.fisher
+import cyvlfeat.kmeans
+import cyvlfeat.generic
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/cyvlfeat/_vl/generic.pxd
+++ b/cyvlfeat/_vl/generic.pxd
@@ -1,0 +1,19 @@
+# Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+# All rights reserved.
+
+# This file is modified from part of the VLFeat library and is made available
+# under the terms of the BSD license.
+
+from .host cimport vl_size, vl_bool
+
+cdef extern from "vl/generic.h":
+    void vl_set_simd_enabled(vl_bool x)
+    vl_bool vl_get_simd_enabled()
+    vl_bool vl_cpu_has_avx()
+    vl_bool vl_cpu_has_sse3()
+    vl_bool vl_cpu_has_sse2()
+    vl_size vl_get_num_cpus()
+    
+    vl_size vl_get_max_threads()
+    void vl_set_num_threads(vl_size n)
+    vl_size vl_get_thread_limit()

--- a/cyvlfeat/generic/__init__.py
+++ b/cyvlfeat/generic/__init__.py
@@ -1,0 +1,1 @@
+from .generic import *

--- a/cyvlfeat/generic/generic.pyx
+++ b/cyvlfeat/generic/generic.pyx
@@ -1,0 +1,38 @@
+# distutils: language = c
+# Copyright (C) 2007-12 Andrea Vedaldi and Brian Fulkerson.
+# All rights reserved.
+
+# This file is modified from part of the VLFeat library and is made available
+# under the terms of the BSD license.
+cimport cython
+from cyvlfeat._vl.generic cimport *
+
+
+cpdef void set_simd_enabled(bint x):
+    vl_set_simd_enabled(x)
+
+cpdef bint get_simd_enabled():
+    return vl_get_simd_enabled()
+
+cpdef bint cpu_has_avx():
+    return vl_cpu_has_avx()
+
+cpdef bint cpu_has_sse3():
+    return vl_cpu_has_sse3()
+
+cpdef bint cpu_has_sse2():
+    return vl_cpu_has_sse2()
+
+cpdef int get_num_cpus():
+    return vl_get_num_cpus()
+
+cpdef int get_max_threads():
+    return vl_get_max_threads()
+
+cpdef void set_num_threads(int n):
+    vl_set_num_threads(n)
+
+cpdef int get_thread_limit():
+    return vl_get_thread_limit()
+
+

--- a/cyvlfeat/generic/generic.pyx
+++ b/cyvlfeat/generic/generic.pyx
@@ -24,15 +24,57 @@ cpdef bint cpu_has_sse2():
     return vl_cpu_has_sse2()
 
 cpdef int get_num_cpus():
+    """
+
+    Returns
+    -------
+        Number of CPU cores.
+    """
     return vl_get_num_cpus()
 
 cpdef int get_max_threads():
+    """
+    This function returns the maximum number of thread used by VLFeat.
+    VLFeat will try to use this number of computational threads and never exceed it.
+
+    This is similar to the OpenMP function omp_get_max_threads(); however, it reads
+    a parameter private to VLFeat which is independent of the value used by the OpenMP library.
+
+    If VLFeat was compiled without OpenMP support, this function returns 1.
+
+    Returns
+    -------
+        Number of threads.
+    """
     return vl_get_max_threads()
 
-cpdef void set_num_threads(int n):
-    vl_set_num_threads(n)
+cpdef void set_num_threads(int num_threads):
+    """
+    This function sets the maximum number of computational threads that will be used by VLFeat.
+    VLFeat may in practice use fewer threads (for example because ``num_threads`` is larger than the
+    number of computational cores in the host, or because the number of threads exceeds the
+    limit available to the application).
+
+    If ``num_threads`` is set to 0, then VLFeat sets the number of threads to the OpenMP current
+    maximum, obtained by calling omp_get_max_threads().
+
+    This function is similar to omp_set_num_threads() but changes a parameter internal
+    to VLFeat rather than affecting OpenMP global state.
+
+    If VLFeat was compiled without, this function does nothing.
+    """
+    vl_set_num_threads(num_threads)
 
 cpdef int get_thread_limit():
+    """
+    This function wraps the OpenMP function omp_get_thread_limit().
+    If VLFeat was compiled without OpenMP support, this function returns 1.
+    If VLFeat was compiled with OpenMP prior to version 3.0 (2008/05), it returns 0.
+
+    Returns
+    -------
+        Thread limit.
+    """
     return vl_get_thread_limit()
 
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,9 @@ vl_extensions = [
     gen_extension('cyvlfeat.hog.cyhog',
                   [op.join('cyvlfeat', 'hog', 'cyhog.pyx')]),
     gen_extension('cyvlfeat.kmeans.cykmeans',
-                  [op.join('cyvlfeat', 'kmeans', 'cykmeans.pyx')])
+                  [op.join('cyvlfeat', 'kmeans', 'cykmeans.pyx')]),
+    gen_extension('cyvlfeat.generic.generic',
+                  [op.join('cyvlfeat', 'generic', 'generic.pyx')])
 ]
 
 # Grab all the pyx and pxd Cython files for uploading to pypi


### PR DESCRIPTION
Simple wrapping around the functions controlling the number of threads that can be used by vlfeat.

These are only useful if vlfeat was compiled with multi-thread support which is **currently disabled by the vlfeat conda package** though.