### PR TITLE
Array ordering for SIFT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ cyvlfeat.egg-info/*
 
 # Let's just ignore all cython built files
 cyvlfeat/hog/cyhog.c
+cyvlfeat/generic/generic.c
+cyvlfeat/kmeans/cykmeans.c
 cyvlfeat/sift/cysift.c
 cyvlfeat/fisher/cyfisher.c
 *.iml

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -8,7 +8,7 @@ if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
 fi
 if [ "$(uname -s)" == "Darwin" ]; then
   export CFLAGS="-I$PREFIX/include -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET $CFLAGS"
-  export LDFLAGS="-L$PREFIX/lib $LDFLAGS"
+  export LDFLAGS="-L$PREFIX/lib -Wl,-headerpad_max_install_names $LDFLAGS"
 fi
 
 "$PYTHON" setup.py install --single-version-externally-managed --record=/tmp/record.txt

--- a/cyvlfeat/sift/cysift.pyx
+++ b/cyvlfeat/sift/cysift.pyx
@@ -314,7 +314,14 @@ cpdef cy_sift(np.ndarray[float, ndim=2, mode='c'] data, int n_octaves,
 
                 # Dynamically reallocate the output arrays so that they can
                 # fit all the keypoints being requested.
-                if reserved < total_keypoints + 1:
+                # If statement says: IF we will run out of space next iteration
+                #                    AND we have computed the frame OR the user
+                #                        has allowed estimation of the number of
+                #                        orientations AND there was more than one
+                #                    THEN reallocate memory
+                if (reserved < total_keypoints + 1 and
+                   (not user_specified_frames or
+                    (force_orientations and n_angles > 1))):
                     reserved += 2 * n_keypoints
 
                     out_frames = np.resize(out_frames, (reserved, 4))
@@ -350,7 +357,7 @@ cpdef cy_sift(np.ndarray[float, ndim=2, mode='c'] data, int n_octaves,
     # If we have dynamically allocated memory for the frames, make sure that
     # we resize the array back to the correct size (since we optimistically
     # allocated previously to reduce the number of total resizes)
-    if not user_specified_frames:
+    if out_frames.shape[0] != total_keypoints:
         out_frames = np.resize(out_frames, (total_keypoints, 4))
         out_descriptors = np.resize(out_descriptors, (total_keypoints, 128))
 

--- a/cyvlfeat/sift/tests/sift_test.py
+++ b/cyvlfeat/sift/tests/sift_test.py
@@ -70,7 +70,7 @@ def test_dsift_norm():
 def test_sift_n_frames():
     i = img.copy()
     frames = sift(i)
-    assert_allclose(frames[0], [2.16217, 128.056, 2.13029, -4.3617], rtol=1e-3)
+    assert_allclose(frames[0], [2.16217, 128.056, 2.13029, 5.9325], rtol=1e-3)
     assert frames.shape[0] == 730
 
 
@@ -78,8 +78,8 @@ def test_sift_non_float_descriptors():
     i = half_img.copy()
     frames, descriptors = sift(i, compute_descriptor=True)
 
-    assert_allclose(frames[0], [2.16217, 128.056, 2.13029, -4.3617], rtol=1e-3)
-    assert_allclose(descriptors[0, 47:52], [53, 131, 137, 32, 14])
+    assert_allclose(frames[0], [2.16217, 128.056, 2.13029, 5.9325], rtol=1e-3)
+    assert_allclose(descriptors[0, 84:88], [4,  14,  32, 137])
     assert frames.shape[0] == 358
 
 
@@ -90,7 +90,7 @@ def test_sift_user_defined_frames():
     new_frames, descriptors = sift(i, frames=frames, compute_descriptor=True)
 
     assert_allclose(new_frames[0], frames[0], rtol=1e-3)
-    assert_allclose(descriptors[0, -5:], [2, 10, 23, 22, 14])
+    assert_allclose(descriptors[0, -5:], [14, 22, 23, 10,  2])
     assert new_frames.shape[0] == 3
 
 
@@ -101,7 +101,7 @@ def test_sift_sort_user_defined_scales():
     new_frames, descriptors = sift(i, frames=frames, compute_descriptor=True)
 
     assert_allclose(new_frames[0], frames[-1], rtol=1e-3)
-    assert_allclose(descriptors[0, -5:], [22, 137, 36, 0, 0])
+    assert_allclose(descriptors[0, -5:], [46, 14,  0,  0,  0])
     assert new_frames.shape[0] == 3
 
 
@@ -112,6 +112,6 @@ def test_sift_force_orientations():
     new_frames, descriptors = sift(i, frames=frames, compute_descriptor=True,
                                    force_orientations=True)
 
-    assert_allclose(new_frames[0], [4, 5, 2, -3.0531], rtol=1e-3)
-    assert_allclose(descriptors[0, :5], [8, 28, 30, 19, 38])
+    assert_allclose(new_frames[0], [4, 5, 2, 4.6239], rtol=1e-3)
+    assert_allclose(descriptors[0, :5], [5, 1, 0, 0, 1])
     assert new_frames.shape[0] == 3

--- a/cyvlfeat/sift/tests/sift_test.py
+++ b/cyvlfeat/sift/tests/sift_test.py
@@ -91,7 +91,7 @@ def test_sift_user_defined_frames():
 
     assert_allclose(new_frames[0], frames[0], rtol=1e-3)
     assert_allclose(descriptors[0, -5:], [2, 10, 23, 22, 14])
-    assert frames.shape[0] == 3
+    assert new_frames.shape[0] == 3
 
 
 def test_sift_sort_user_defined_scales():
@@ -102,7 +102,7 @@ def test_sift_sort_user_defined_scales():
 
     assert_allclose(new_frames[0], frames[-1], rtol=1e-3)
     assert_allclose(descriptors[0, -5:], [22, 137, 36, 0, 0])
-    assert frames.shape[0] == 3
+    assert new_frames.shape[0] == 3
 
 
 def test_sift_force_orientations():
@@ -114,4 +114,4 @@ def test_sift_force_orientations():
 
     assert_allclose(new_frames[0], [4, 5, 2, -3.0531], rtol=1e-3)
     assert_allclose(descriptors[0, :5], [8, 28, 30, 19, 38])
-    assert frames.shape[0] == 3
+    assert new_frames.shape[0] == 3


### PR DESCRIPTION
As mentioned by @alexismignon in Issue #17, the array ordering is incorrect for sparse SIFT. This should remedy that. It also fixes a bug whereby user defined frames were not being resized correctly (missed by the tests due to a copy paste error).