### PR TITLE
Corrected array ordering problem for the fisher module

### DIFF
--- a/cyvlfeat/fisher/fisher.py
+++ b/cyvlfeat/fisher/fisher.py
@@ -13,14 +13,14 @@ def fisher(x, means, covariances, priors, normalized=False, square_root=False,
 
     Parameters
     ----------
-    x : [D, N]  `float32` `ndarray`
+    x : [n_samples, n_features]  `float32` `ndarray`
         One column per data vector (e.g. a SIFT descriptor)
-    means :  [F, N]  `float32` `ndarray`
+    means :  [n_clusters, n_features]  `float32` `ndarray`
         One column per GMM component.
-    covariances :  [F, N]  `float32` `ndarray`
+    covariances :  [n_clusters, n_features]  `float32` `ndarray`
         One column per GMM component (covariance matrices are assumed diagonal,
         hence these are simply the variance of each data dimension).
-    priors :  [F, N]  `float32` `ndarray`
+    priors :  [n_clusters]  `float32` `ndarray`
         Equal to the number of GMM components.
     normalized : `bool`, optional
         If ``True``, L2 normalize the Fisher vector.
@@ -48,22 +48,27 @@ def fisher(x, means, covariances, priors, normalized=False, square_root=False,
         raise ValueError('A required input is None')
 
     # validate the gmm parameters
-    D = means.shape[0]  # the feature dimensionality
-    K = means.shape[1]  # the number of GMM modes
+    D = means.shape[1]  # the feature dimensionality
+    K = means.shape[0]  # the number of GMM modes
     # N = x.shape[1] is the number of samples
-    if covariances.shape[0] != D:
+    if covariances.shape[1] != D:
         raise ValueError('covariances and means do not have the same '
                          'dimensionality')
-    
+
     if priors.ndim != 1:
         raise ValueError('priors has an unexpected shape')
-    
-    if covariances.shape[1] != K or priors.shape[0] != K:
+
+    if covariances.shape[0] != K or priors.shape[0] != K:
         raise ValueError('covariances or priors does not have the correct '
                          'number of modes')
 
-    if x.shape[0] != D:
+    if x.shape[1] != D:
         raise ValueError('x and means do not have the same dimensionality')
+
+    x = np.ascontiguousarray(x)
+    means = np.ascontiguousarray(means)
+    covariances = np.ascontiguousarray(covariances)
+    priors = np.ascontiguousarray(priors)
 
     return cy_fisher(x, means, covariances, priors,
                      np.int32(normalized), np.int32(square_root),

--- a/cyvlfeat/fisher/tests/fisher_test.py
+++ b/cyvlfeat/fisher/tests/fisher_test.py
@@ -7,48 +7,72 @@ def test_fisher_dimension():
     N = 1000
     K = 512
     D = 128
-    
-    x = np.random.uniform(size=(D, N)).astype(np.float32)
-    means = np.random.uniform(size=(D, K)).astype(np.float32)
-    covariances = np.random.uniform(size=(D, K)).astype(np.float32)
+
+    x = np.random.uniform(size=(N, D)).astype(np.float32)
+    means = np.random.uniform(size=(K, D)).astype(np.float32)
+    covariances = np.random.uniform(size=(K, D)).astype(np.float32)
     priors = np.random.uniform(size=(K,)).astype(np.float32)
     priors /= np.linalg.norm(priors)
     enc = fisher(x, means, covariances, priors, verbose=True)
-    
+
     expected = 2 * K * D
     observed = len(enc)
     assert(expected == observed)
 
 
+def _compute_posteriors(diff, covars, prior):
+    q = (diff ** 2).sum(-1)  # Mahalanobis distances to cluster centers
+    # Compute the log probability of samples knowing each cluster
+    q = -0.5 * (q + np.log(covars).sum(-1) +
+                diff.shape[1] * np.log(2 * np.pi))
+    # Compute the joint probability of xi and j-th cluster
+    # p(xi, cj) = p(xi|cj) * p(cj)
+    q += np.log(prior)
+    # Normalize values to avoid numerical problems
+    qmax = q.max(-1)
+    q -= qmax[:, None]
+    # Compute the posteriors
+    q = np.exp(q)
+    # normalize
+    q /= q.sum(-1)[:, np.newaxis]
+    return q
+
+
+def _fisher_encoding(X, means, covars, priors):
+    diff = (X[:, None] - means[None]) / np.sqrt(covars)
+    q = _compute_posteriors(diff, covars, priors)
+    u = (diff * q[..., np.newaxis]).mean(0) / np.sqrt(priors)[:, np.newaxis]
+    v = ((diff ** 2 - 1) * q[..., np.newaxis]).mean(0) / \
+        np.sqrt(2 * priors)[:, np.newaxis]
+    return np.hstack([u.ravel(), v.ravel()])
+
+
 def test_fisher_encoding():
-    N = 21
-    K = 3
-    D = 5
-    x = np.zeros(D * N, dtype=np.float32)
-    for i in range(D * N):
-        x[i] = i
-    x = x.reshape(D, N)
+    X = np.random.randn(1000, 2)
+    X[500:] *= (2, 3)
+    X[500:] += (4, 4)
 
-    mu = np.zeros(D * K, dtype=np.float32)
-    for i in range(D * K):
-        mu[i] = i
-    mu = mu.reshape(D, K)
-    
-    sigma2 = np.ones((D, K), dtype=np.float32)
-    prior = (1.0 / K) * np.ones(K, dtype=np.float32)
+    mu = np.asarray(
+        [[0., 0.], [4., 4.]]
+    )
 
-    observed_enc = fisher(x, mu, sigma2, prior, verbose=True)
+    sigma2 = np.asarray(
+        [[1.0, 1.0], [2.0, 3.0]]
+    )
 
-    # expected result obtained from running vl_fisher_encode from a C program
-    expected_enc = np.array([0.000000000, 0.000000000, 0.000000000,
-                             0.000000000, 0.000000000, 0.000000000,
-                             0.000000000, 0.000000000, 0.000000000,
-                             0.000000000, 70.519210815, 70.519210815,
-                             70.519210815, 70.519210815, 70.519210815,
-                             -0.058321182, -0.058321182, -0.058321182,
-                             -0.058321182, -0.058321182, -0.058321182,
-                             -0.058321182, -0.058321182, -0.058321182,
-                             -0.058321182, 3073.876220703, 3073.876220703,
-                             3073.876220703, 3073.876220703, 3073.876220703],
-                            dtype=np.float32)
-    assert_allclose(expected_enc, observed_enc)
+    prior = np.asarray(
+        [0.6, 0.4]
+    )
+
+    expected_enc = _fisher_encoding(X, mu, sigma2, prior)
+    observed_enc = fisher(X, mu, sigma2, prior, verbose=True)
+
+    assert_allclose(expected_enc, observed_enc, rtol=1e-4)
+
+    observed_enc = fisher(X.astype("float32"),
+                          mu.astype("float32"),
+                          sigma2.astype("float32"),
+                          prior.astype("float32"), verbose=True)
+
+    assert_allclose(expected_enc, observed_enc, rtol=1e-4)
+    assert observed_enc.dtype == "float32"

--- a/cyvlfeat/fisher/tests/fisher_test.py
+++ b/cyvlfeat/fisher/tests/fisher_test.py
@@ -48,6 +48,7 @@ def _fisher_encoding(X, means, covars, priors):
 
 
 def test_fisher_encoding():
+    np.random.seed(1)
     X = np.random.randn(1000, 2)
     X[500:] *= (2, 3)
     X[500:] += (4, 4)


### PR DESCRIPTION
This pull request proposes the following changes
- There was a problem with the array ordering in the fisher module
- The expected input array are transposed
- The new test case directly computes the expected output and compares it to the obtained one
- Added the possibility to use input data in float64 
