### PR TITLE
Changing 3D pixel order from python to matlab

### DIFF
--- a/cyvlfeat/hog/cyhog.pyx
+++ b/cyvlfeat/hog/cyhog.pyx
@@ -15,7 +15,7 @@ from cyvlfeat.cy_util cimport py_printf, set_python_vl_printf
 
 
 @cython.boundscheck(False)
-cpdef cy_hog(float[:, :, ::1] data, int cell_size, int variant,
+cpdef cy_hog(float[:, :, :] data, int cell_size, int variant,
              int n_orientations, bint directed_polar_field,
              bint undirected_polar_field, bint bilinear_interpolation,
              bint return_channels_last_axis, bint verbose):

--- a/cyvlfeat/hog/hog.py
+++ b/cyvlfeat/hog/hog.py
@@ -66,6 +66,10 @@ def hog(image, cell_size, variant='UoCTTI', n_orientations=9,
     # Add a channels axis
     if image.ndim == 2:
         image = image[..., None]
+    elif image.ndim == 3:
+        channels = [x.squeeze() for x in np.split(image, 3, axis=2)]
+        image_shape = image.shape
+        image = np.hstack([c.ravel() for c in channels]).reshape(image_shape)
 
     # Validate image size
     if image.ndim != 3:

--- a/cyvlfeat/hog/hog.py
+++ b/cyvlfeat/hog/hog.py
@@ -66,7 +66,10 @@ def hog(image, cell_size, variant='UoCTTI', n_orientations=9,
     # Add a channels axis
     if image.ndim == 2:
         image = image[..., None]
-    elif image.ndim == 3:
+    elif image.ndim == 3 and image.shape[0] <= 3:
+        pass  # manpo standard / channels are the first axis
+    elif image.ndim == 3 and image.shape[2] <= 3:
+        # rearranging the data to the same way matlab stores images
         channels = [x.squeeze() for x in np.split(image, 3, axis=2)]
         image_shape = image.shape
         image = np.hstack([c.ravel() for c in channels]).reshape(image_shape)

--- a/cyvlfeat/hog/hog.py
+++ b/cyvlfeat/hog/hog.py
@@ -66,13 +66,6 @@ def hog(image, cell_size, variant='UoCTTI', n_orientations=9,
     # Add a channels axis
     if image.ndim == 2:
         image = image[..., None]
-    elif image.ndim == 3 and image.shape[0] <= 3:
-        pass  # manpo standard / channels are the first axis
-    elif image.ndim == 3 and image.shape[2] <= 3:
-        # rearranging the data to the same way matlab stores images
-        channels = [x.squeeze() for x in np.split(image, 3, axis=2)]
-        image_shape = image.shape
-        image = np.hstack([c.ravel() for c in channels]).reshape(image_shape)
 
     # Validate image size
     if image.ndim != 3:
@@ -89,7 +82,7 @@ def hog(image, cell_size, variant='UoCTTI', n_orientations=9,
         raise ValueError('Expected a polar field image of n_channels == 2')
 
     # Ensure types are correct before passing to Cython
-    image = np.require(image, dtype=np.float32, requirements='C')
+    image = np.require(image, dtype=np.float32, requirements='F')
 
     # Shortcut for getting the correct enum value, since is_UoCTTI has
     # an enum value of 1 (True is 1 in Python)

--- a/cyvlfeat/hog/tests/hog_test.py
+++ b/cyvlfeat/hog/tests/hog_test.py
@@ -15,8 +15,8 @@ def test_hog_cell_size_32_uoctti():
     assert output.dtype == np.float32
     assert output.shape == (16, 16, 31)
     assert_allclose(output[:2, :2, 0],
-                    np.array([[0.16276041, 0.13416694],
-                              [0.22367628, 0.17556792]]), rtol=1e-5)
+                    np.array([[0.104189, 0.056746],
+                              [0.051333, 0.03721]]), rtol=1e-4)
 
 
 def test_hog_cell_size_32_uoctti_4_orientations():
@@ -25,8 +25,8 @@ def test_hog_cell_size_32_uoctti_4_orientations():
     assert output.dtype == np.float32
     assert output.shape == (16, 16, 16)
     assert_allclose(output[:2, :2, 0],
-                    np.array([[0.23047766, 0.17703892],
-                              [0.30189356, 0.25290328]]), rtol=1e-5)
+                    np.array([[0.158388,  0.085595],
+                              [0.078716,  0.062816]]), rtol=1e-5)
 
 
 def test_hog_cell_size_32_uoctti_non_square():
@@ -35,8 +35,8 @@ def test_hog_cell_size_32_uoctti_non_square():
     assert output.dtype == np.float32
     assert output.shape == (16, 8, 31)
     assert_allclose(output[:2, :2, 0],
-                    np.array([[0.16276041, 0.13416694],
-                              [0.22367628, 0.17556792]]), rtol=1e-5)
+                    np.array([[0.163912, 0.167787],
+                              [0.086294, 0.079365]]), rtol=1e-5)
 
 
 def test_hog_cell_size_32_dalaltriggs():
@@ -45,8 +45,8 @@ def test_hog_cell_size_32_dalaltriggs():
     assert output.dtype == np.float32
     assert output.shape == (16, 16, 36)
     assert_allclose(output[:2, :2, 0],
-                    np.array([[0.2, 0.2],
-                              [0.2, 0.2]]))
+                    np.array([[0.139408, 0.093407],
+                              [0.070996, 0.065033]]), rtol=1e-5)
 
 
 def test_hog_cell_size_32_dalaltriggs_4_orientations():
@@ -55,8 +55,8 @@ def test_hog_cell_size_32_dalaltriggs_4_orientations():
     assert output.dtype == np.float32
     assert output.shape == (16, 16, 16)
     assert_allclose(output[:2, :2, 0],
-                    np.array([[0.2, 0.2],
-                              [0.2, 0.2]]))
+                    np.array([[0.2,      0.154738],
+                              [0.109898, 0.108115]]), rtol=1e-5)
 
 
 def test_hog_cell_size_32_dalaltriggs_non_square():
@@ -65,8 +65,8 @@ def test_hog_cell_size_32_dalaltriggs_non_square():
     assert output.dtype == np.float32
     assert output.shape == (16, 8, 36)
     assert_allclose(output[:2, :2, 0],
-                    np.array([[0.2, 0.2],
-                              [0.2, 0.2]]), rtol=1e-5)
+                    np.array([[0.2,       0.2],
+                              [0.144946,  0.192144]]), rtol=1e-5)
 
 
 def test_hog_cell_size_32_dalaltriggs_bilinear_interpolation():
@@ -75,5 +75,5 @@ def test_hog_cell_size_32_dalaltriggs_bilinear_interpolation():
     assert output.dtype == np.float32
     assert output.shape == (16, 16, 36)
     assert_allclose(output[:2, -2:, 0],
-                    np.array([[0.082442075, 0.13325043],
-                              [0.094600961, 0.090005033]]), rtol=1e-5)
+                    np.array([[0.01523,  0.017774],
+                              [0.012941, 0.012733]]), rtol=1e-4)


### PR DESCRIPTION
Python and open CV stores pixels in memory ordered by channels then rows and then columns. 
That is, assuming w.l.o.g. that data is kept in RGB order, the data is stored in memory as 
R(0,0), G(0,0), B(0,0), R(0,1), G(0,1), B(0,1) ... B(0,W-1), 
R(1,0), G(1,0), B(1,0), R(0,1), G(0,1), B(0,1) ... B(1,W-1), 
...
R(H-1,0), G(H-1,0), B(H-1,0),  ...                 B(H-1,W-1), 

Matlab does it in reversed order:
All red pixels (in column major) then all blue pixels then all green.

In order to get the same HOG result, the data order in memory should be changed.
