### PR TITLE
Exposes edge and peak as float

### DIFF
--- a/cyvlfeat/sift/cysift.pyx
+++ b/cyvlfeat/sift/cysift.pyx
@@ -147,8 +147,8 @@ cdef int korder(const void *a, const void *b) nogil:
 
 @cython.boundscheck(False)
 cpdef cy_sift(float[:, ::1] data, int n_octaves,
-              int n_levels, int first_octave, int peak_threshold,
-              int edge_threshold, float norm_threshold, int magnification,
+              int n_levels, int first_octave, float peak_threshold,
+              float edge_threshold, float norm_threshold, int magnification,
               int window_size, float[:, :] frames, bint force_orientations,
               bint float_descriptors, bint compute_descriptor, bint verbose):
     # Set the vlfeat printing function to the Python stdout

--- a/cyvlfeat/sift/sift.py
+++ b/cyvlfeat/sift/sift.py
@@ -29,10 +29,10 @@ def sift(image, n_octaves=None, n_levels=3,  first_octave=0,  peak_thresh=0,
         The number of levels per octave of the DoG scale space.
     first_octave : `int`, optional
         The index of the first octave of the DoG scale space.
-    peak_thresh : `int`, optional
+    peak_thresh : `float`, optional
         The peak selection threshold. The peak threshold filters peaks of the
         DoG scale space that are too small (in absolute value).
-    edge_thresh : `int`, optional
+    edge_thresh : `float`, optional
         The edge selection threshold. The edge threshold eliminates peaks of the
         DoG scale space whose curvature is too small (such peaks yield badly
         localized frames).
@@ -101,7 +101,7 @@ def sift(image, n_octaves=None, n_levels=3,  first_octave=0,  peak_thresh=0,
         raise ValueError('n_levels must be > 0')
     if first_octave < 0:
         raise ValueError('first_octave must be >= 0')
-    if edge_thresh < 1:
+    if edge_thresh <= 0:
         raise ValueError('edge_thresh must be > 0')
     if peak_thresh < 0:
         raise ValueError('peak_thresh must be >= 0')


### PR DESCRIPTION
The cython wrapper to vl_sift exposed `edge_thresh` and `peak_thresh` as ints.  These are defined as doubles in the [pxd](https://github.com/menpo/cyvlfeat/blob/master/cyvlfeat/_vl/sift.pxd#L47) and in the [vlfeat source](https://github.com/vlfeat/vlfeat/blob/master/toolbox/sift/vl_sift.c#L151).

This PR exposes `edge_thresh` and `peak_thresh` as floats.  This behavior is useful when the source data are not in byte space and additional granularity is necessary to extract high quality SIFT descriptors.